### PR TITLE
feat: implement project artifact detector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,6 +111,7 @@ dependencies = [
  "clap",
  "serde",
  "serde_json",
+ "walkdir",
 ]
 
 [[package]]
@@ -153,6 +154,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -226,6 +236,25 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
+]
 
 [[package]]
 name = "windows-link"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,10 @@ serde = { version = "1", features = ["derive"] }
 # serde alone doesn't include a format, serde_json is the standard json backend
 serde_json = "1"
 
+# filesystem traversal with iterator interface
+# std::fs::read_dir is too low level, walkdir handles recursion and symlink policy
+walkdir = "2"
+
 [dev-dependencies]
 
 [[bin]]

--- a/README.md
+++ b/README.md
@@ -1,31 +1,39 @@
 # heft
 
-A disk space auditor for developers that shows where your space went and how much you can safely reclaim.
+Shows you where your disk space went and what you can delete.
 
-## The Problem
+## why
 
-Developer workstations accumulate disk bloat silently. Docker images pile up, node_modules multiply across abandoned projects, cargo targets grow unbounded, package manager caches swell in hidden directories. A typical polyglot developer can lose 40-80 GB to reclaimable junk without realizing it.
+If youve ever run out of disk space and spent an hour figuring out what to delete, this is for you. node_modules from projects you forgot about, cargo target directories that somehow grew to 5gb, python venvs everywhere. Its always the same stuff but you have to hunt for it every time.
 
-## Status
+heft finds it all in one scan.
 
-Early development. Not yet usable. The project skeleton exists but core functionality is being implemented.
+## status
 
-## Building
+Work in progress. The project artifact scanner works. Cache detection and docker support coming next.
+
+## usage
+
+```
+heft scan --roots ~/code
+```
+
+Finds node_modules, cargo targets, python venvs, pycache, gradle builds, xcode deriveddata, go vendor dirs. Shows you the size of each and which ones are safe to delete.
+
+## building
 
 ```
 cargo build
 cargo test
 ```
 
-## Roadmap
+## whats next
 
-- [ ] v0.1 — Project and cache detectors, TUI table output
-- [ ] v0.2 — Docker detector
-- [ ] v0.3 — Cleanup engine with dry run
-- [ ] v0.4 — SQLite snapshots and diff
-- [ ] v0.5 — JSON output, config file, polish
-- [ ] v1.0 — Stable release, cross platform, published
+- cache detector (npm, pip, cargo, homebrew caches)
+- docker detector (images, volumes, build cache)
+- cleanup command with dry run
+- snapshot history so you can see what grew back
 
-## License
+## license
 
 MIT

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -21,7 +21,7 @@ pub fn print(result: &ScanResult) {
     if !result.diagnostics.is_empty() {
         println!();
         for diagnostic in &result.diagnostics {
-            println!("[diagnostic] {}", diagnostic);
+            println!("[diagnostic] {diagnostic}");
         }
     }
 }

--- a/src/scan/projects.rs
+++ b/src/scan/projects.rs
@@ -1,17 +1,14 @@
-//! Project artifact detector.
-//!
-//! Walks configured root directories looking for known build artifact patterns:
-//! - node_modules (Node.js)
-//! - target/ (Rust/Cargo)
-//! - __pycache__, .venv, venv (Python)
-//! - vendor/ (Go, PHP)
-//! - build/, dist/ (various)
-//! - DerivedData (Xcode)
-//!
-//! Reports per-project size and last modification time of source files.
+//! Detects build artifacts in project directories.
+
+use std::collections::HashSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+use walkdir::WalkDir;
 
 use crate::config::Config;
-use super::detector::{Detector, DetectorResult};
+use super::detector::{BloatCategory, BloatEntry, Detector, DetectorResult, Location};
 
 pub struct ProjectDetector;
 
@@ -24,7 +21,307 @@ impl Detector for ProjectDetector {
         true
     }
 
-    fn scan(&self, _config: &Config) -> DetectorResult {
-        DetectorResult::empty()
+    fn scan(&self, config: &Config) -> DetectorResult {
+        let mut entries = Vec::new();
+        let mut diagnostics = Vec::new();
+        let mut seen_projects: HashSet<PathBuf> = HashSet::new();
+
+        for root in &config.roots {
+            if !root.exists() {
+                diagnostics.push(format!("skipping {}: directory does not exist", root.display()));
+                continue;
+            }
+
+            scan_directory(root, &mut entries, &mut seen_projects, &mut diagnostics);
+        }
+
+        DetectorResult { entries, diagnostics }
     }
+}
+
+fn scan_directory(
+    root: &Path,
+    entries: &mut Vec<BloatEntry>,
+    seen_projects: &mut HashSet<PathBuf>,
+    diagnostics: &mut Vec<String>,
+) {
+    // once we find an artifact like node_modules, we dont want to look inside it
+    // for more artifacts. this set tracks what weve already claimed.
+    let mut seen_artifacts: HashSet<PathBuf> = HashSet::new();
+
+    let walker = WalkDir::new(root)
+        .follow_links(false)
+        .into_iter()
+        .filter_entry(|e| !is_hidden(e.file_name()));
+
+    for entry in walker.filter_map(|e| e.ok()) {
+        if !entry.file_type().is_dir() {
+            continue;
+        }
+
+        let path = entry.path();
+
+        // already inside something we detected, skip
+        if seen_artifacts.iter().any(|seen| path.starts_with(seen)) {
+            continue;
+        }
+
+        let dir_name = match path.file_name().and_then(|n| n.to_str()) {
+            Some(name) => name,
+            None => continue,
+        };
+
+        if let Some(artifact) = detect_artifact(path, dir_name) {
+            let project_root = path.parent().unwrap_or(path);
+
+            // monorepos have node_modules at root and also in each package.
+            // if weve seen the root already, skip the nested ones.
+            if seen_projects.iter().any(|seen| project_root.starts_with(seen)) {
+                seen_artifacts.insert(path.to_path_buf());
+                continue;
+            }
+
+            match calculate_dir_size(path) {
+                Ok(size) => {
+                    let project_name = determine_project_name(project_root, &artifact);
+                    let last_modified = get_source_last_modified(project_root);
+
+                    entries.push(BloatEntry {
+                        category: BloatCategory::ProjectArtifacts,
+                        name: project_name,
+                        location: Location::FilesystemPath(path.to_path_buf()),
+                        size_bytes: size,
+                        reclaimable_bytes: size,
+                        last_modified,
+                        cleanup_hint: Some(artifact.cleanup_hint.to_string()),
+                    });
+
+                    seen_projects.insert(project_root.to_path_buf());
+                    seen_artifacts.insert(path.to_path_buf());
+                }
+                Err(e) => {
+                    diagnostics.push(format!("failed to calculate size of {}: {}", path.display(), e));
+                }
+            }
+        }
+    }
+}
+
+struct ArtifactType {
+    cleanup_hint: &'static str,
+    manifest_file: Option<&'static str>,
+}
+
+// checks if a directory is a known build artifact. returns info about how to
+// clean it up and where to find the project name.
+fn detect_artifact(path: &Path, dir_name: &str) -> Option<ArtifactType> {
+    let parent = path.parent()?;
+
+    match dir_name {
+        "node_modules" => Some(ArtifactType {
+            cleanup_hint: "safe to delete, reinstall with npm install",
+            manifest_file: Some("package.json"),
+        }),
+
+        // lots of projects have a target dir, only match if theres a Cargo.toml
+        "target" if parent.join("Cargo.toml").exists() => Some(ArtifactType {
+            cleanup_hint: "safe to delete, rebuild with cargo build",
+            manifest_file: Some("Cargo.toml"),
+        }),
+
+        // python caches show up everywhere including inside installed packages.
+        // only count ones that are in actual projects, not in site-packages.
+        "__pycache__" | ".pytest_cache" | ".mypy_cache" | ".tox"
+            if !is_inside_installed_packages(path) => Some(ArtifactType {
+                cleanup_hint: "safe to delete, regenerated automatically",
+                manifest_file: None,
+            }),
+
+        ".venv" | "venv" if has_python_project(parent) => Some(ArtifactType {
+            cleanup_hint: "virtual environment, recreate with python -m venv",
+            manifest_file: None,
+        }),
+
+        "vendor" if parent.join("go.mod").exists() => Some(ArtifactType {
+            cleanup_hint: "safe to delete, restore with go mod vendor",
+            manifest_file: Some("go.mod"),
+        }),
+
+        "vendor" if parent.join("composer.json").exists() => Some(ArtifactType {
+            cleanup_hint: "safe to delete, restore with composer install",
+            manifest_file: Some("composer.json"),
+        }),
+
+        ".gradle" | "build" if parent.join("build.gradle").exists() || parent.join("build.gradle.kts").exists() => {
+            Some(ArtifactType {
+                cleanup_hint: "safe to delete, rebuild with gradle build",
+                manifest_file: None,
+            })
+        }
+
+        "DerivedData" => Some(ArtifactType {
+            cleanup_hint: "xcode build artifacts, safe to delete",
+            manifest_file: None,
+        }),
+
+        _ => None,
+    }
+}
+
+fn has_python_project(dir: &Path) -> bool {
+    dir.join("requirements.txt").exists()
+        || dir.join("setup.py").exists()
+        || dir.join("pyproject.toml").exists()
+        || dir.join("setup.cfg").exists()
+}
+
+fn is_inside_installed_packages(path: &Path) -> bool {
+    let path_str = path.to_string_lossy();
+    path_str.contains("site-packages")
+        || path_str.contains("dist-packages")
+        || path_str.contains("node_modules")
+        || path_str.contains(".venv")
+        || path_str.contains("/venv/")
+}
+
+// we skip hidden directories during traversal, but some artifacts we care about
+// start with a dot. this returns false for those so we still find them.
+fn is_hidden(name: &std::ffi::OsStr) -> bool {
+    name.to_str()
+        .map(|s| {
+            if !s.starts_with('.') {
+                return false;
+            }
+            !matches!(s, ".venv" | ".pytest_cache" | ".mypy_cache" | ".tox" | ".gradle")
+        })
+        .unwrap_or(false)
+}
+
+fn calculate_dir_size(path: &Path) -> Result<u64, std::io::Error> {
+    let mut total = 0u64;
+
+    for entry in WalkDir::new(path).follow_links(false).into_iter().filter_map(|e| e.ok()) {
+        if entry.file_type().is_file() {
+            if let Ok(metadata) = entry.metadata() {
+                total += metadata.len();
+            }
+        }
+    }
+
+    Ok(total)
+}
+
+fn determine_project_name(project_root: &Path, artifact: &ArtifactType) -> String {
+    if let Some(manifest) = artifact.manifest_file {
+        let manifest_path = project_root.join(manifest);
+        if let Some(name) = read_project_name_from_manifest(&manifest_path) {
+            return name;
+        }
+    }
+
+    project_root
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("unknown")
+        .to_string()
+}
+
+fn read_project_name_from_manifest(path: &Path) -> Option<String> {
+    let content = fs::read_to_string(path).ok()?;
+    let filename = path.file_name()?.to_str()?;
+
+    match filename {
+        "package.json" => extract_json_field(&content, "name"),
+        "Cargo.toml" => extract_toml_package_name(&content),
+        "go.mod" => content.lines().next()
+            .and_then(|line| line.strip_prefix("module "))
+            .map(|s| s.trim().to_string()),
+        _ => None,
+    }
+}
+
+// pulls a string field out of json without a full parser. good enough for
+// grabbing "name" from a package.json, not meant for complex cases.
+fn extract_json_field(content: &str, field: &str) -> Option<String> {
+    let pattern = format!("\"{field}\"");
+    let start = content.find(&pattern)?;
+    let after_key = &content[start + pattern.len()..];
+    let colon_pos = after_key.find(':')?;
+    let after_colon = after_key[colon_pos + 1..].trim_start();
+
+    if !after_colon.starts_with('"') {
+        return None;
+    }
+
+    let value_end = after_colon[1..].find('"')?;
+    Some(after_colon[1..1 + value_end].to_string())
+}
+
+fn extract_toml_package_name(content: &str) -> Option<String> {
+    let mut in_package = false;
+
+    for line in content.lines() {
+        let trimmed = line.trim();
+
+        if trimmed == "[package]" {
+            in_package = true;
+            continue;
+        }
+
+        if trimmed.starts_with('[') {
+            in_package = false;
+            continue;
+        }
+
+        if in_package && trimmed.starts_with("name") {
+            let parts: Vec<&str> = trimmed.splitn(2, '=').collect();
+            if parts.len() == 2 {
+                let value = parts[1].trim().trim_matches('"').trim_matches('\'');
+                return Some(value.to_string());
+            }
+        }
+    }
+
+    None
+}
+
+// finds the most recent modification time of source files in a project.
+// used to identify stale projects that havent been touched in a while.
+fn get_source_last_modified(project_root: &Path) -> Option<i64> {
+    let mut latest: Option<SystemTime> = None;
+    let source_extensions = ["rs", "js", "ts", "jsx", "tsx", "py", "go", "java", "kt", "swift"];
+
+    // only check top few levels, dont need to go deep
+    for entry in WalkDir::new(project_root)
+        .max_depth(3)
+        .follow_links(false)
+        .into_iter()
+        .filter_map(|e| e.ok())
+    {
+        let path = entry.path();
+
+        if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+            if matches!(name, "node_modules" | "target" | ".venv" | "venv" | "vendor" | "__pycache__" | "build" | "dist") {
+                continue;
+            }
+        }
+
+        if entry.file_type().is_file() {
+            let is_source = path.extension()
+                .and_then(|e| e.to_str())
+                .map(|ext| source_extensions.contains(&ext))
+                .unwrap_or(false);
+
+            if is_source {
+                if let Ok(metadata) = entry.metadata() {
+                    if let Ok(modified) = metadata.modified() {
+                        latest = Some(latest.map_or(modified, |l| l.max(modified)));
+                    }
+                }
+            }
+        }
+    }
+
+    latest.and_then(|t| t.duration_since(SystemTime::UNIX_EPOCH).ok())
+        .map(|d| d.as_secs() as i64)
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,14 +1,46 @@
-use std::path::PathBuf;
+use std::fs;
 use std::time::Duration;
 
 use heft::config::Config;
 use heft::platform::Platform;
 use heft::scan;
+use heft::scan::detector::BloatCategory;
 
 #[test]
-fn skeleton_compiles_and_returns_empty_results() {
+fn empty_directory_returns_no_entries() {
+    let temp = std::env::temp_dir().join("heft_test_empty");
+    let _ = fs::remove_dir_all(&temp);
+    fs::create_dir_all(&temp).unwrap();
+
     let config = Config {
-        roots: vec![PathBuf::from("/tmp")],
+        roots: vec![temp.clone()],
+        timeout: Duration::from_secs(30),
+        skip_docker: true,
+        json_output: false,
+        platform: Platform::Linux,
+    };
+
+    let result = scan::run(&config);
+    assert!(result.entries.is_empty());
+
+    let _ = fs::remove_dir_all(&temp);
+}
+
+#[test]
+fn detects_node_modules_in_project() {
+    let temp = std::env::temp_dir().join("heft_test_node");
+    let _ = fs::remove_dir_all(&temp);
+
+    let project = temp.join("my-project");
+    let node_modules = project.join("node_modules");
+    let fake_package = node_modules.join("fake-pkg");
+
+    fs::create_dir_all(&fake_package).unwrap();
+    fs::write(project.join("package.json"), r#"{"name": "my-project"}"#).unwrap();
+    fs::write(fake_package.join("index.js"), "module.exports = {}").unwrap();
+
+    let config = Config {
+        roots: vec![temp.clone()],
         timeout: Duration::from_secs(30),
         skip_docker: true,
         json_output: false,
@@ -17,5 +49,191 @@ fn skeleton_compiles_and_returns_empty_results() {
 
     let result = scan::run(&config);
 
+    assert_eq!(result.entries.len(), 1);
+    assert_eq!(result.entries[0].name, "my-project");
+    assert_eq!(result.entries[0].category, BloatCategory::ProjectArtifacts);
+    assert!(result.entries[0].size_bytes > 0);
+
+    let _ = fs::remove_dir_all(&temp);
+}
+
+#[test]
+fn detects_cargo_target_in_rust_project() {
+    let temp = std::env::temp_dir().join("heft_test_rust");
+    let _ = fs::remove_dir_all(&temp);
+
+    let project = temp.join("my-crate");
+    let target = project.join("target");
+    let debug = target.join("debug");
+
+    fs::create_dir_all(&debug).unwrap();
+    fs::write(project.join("Cargo.toml"), "[package]\nname = \"my-crate\"\nversion = \"0.1.0\"").unwrap();
+    fs::write(debug.join("my-crate"), "fake binary content here").unwrap();
+
+    let config = Config {
+        roots: vec![temp.clone()],
+        timeout: Duration::from_secs(30),
+        skip_docker: true,
+        json_output: false,
+        platform: Platform::Linux,
+    };
+
+    let result = scan::run(&config);
+
+    assert_eq!(result.entries.len(), 1);
+    assert_eq!(result.entries[0].name, "my-crate");
+    assert_eq!(result.entries[0].category, BloatCategory::ProjectArtifacts);
+
+    let _ = fs::remove_dir_all(&temp);
+}
+
+#[test]
+fn skips_nested_node_modules_in_monorepo() {
+    let temp = std::env::temp_dir().join("heft_test_monorepo");
+    let _ = fs::remove_dir_all(&temp);
+
+    let root = temp.join("monorepo");
+    let root_nm = root.join("node_modules");
+    let pkg_a = root.join("packages").join("pkg-a");
+    let nested_nm = pkg_a.join("node_modules");
+
+    fs::create_dir_all(&root_nm).unwrap();
+    fs::create_dir_all(&nested_nm).unwrap();
+    fs::write(root.join("package.json"), r#"{"name": "monorepo"}"#).unwrap();
+    fs::write(pkg_a.join("package.json"), r#"{"name": "pkg-a"}"#).unwrap();
+    fs::write(root_nm.join("dep.js"), "x").unwrap();
+    fs::write(nested_nm.join("dep.js"), "y").unwrap();
+
+    let config = Config {
+        roots: vec![temp.clone()],
+        timeout: Duration::from_secs(30),
+        skip_docker: true,
+        json_output: false,
+        platform: Platform::Linux,
+    };
+
+    let result = scan::run(&config);
+
+    // should only detect the root node_modules, not the nested one
+    assert_eq!(result.entries.len(), 1);
+    assert_eq!(result.entries[0].name, "monorepo");
+
+    let _ = fs::remove_dir_all(&temp);
+}
+
+#[test]
+fn detects_python_venv() {
+    let temp = std::env::temp_dir().join("heft_test_python");
+    let _ = fs::remove_dir_all(&temp);
+
+    let project = temp.join("my-python-project");
+    let venv = project.join(".venv");
+    let site_packages = venv.join("lib").join("python3.11").join("site-packages");
+
+    fs::create_dir_all(&site_packages).unwrap();
+    fs::write(project.join("requirements.txt"), "requests==2.28.0").unwrap();
+    fs::write(site_packages.join("requests.py"), "# fake").unwrap();
+
+    let config = Config {
+        roots: vec![temp.clone()],
+        timeout: Duration::from_secs(30),
+        skip_docker: true,
+        json_output: false,
+        platform: Platform::Linux,
+    };
+
+    let result = scan::run(&config);
+
+    assert_eq!(result.entries.len(), 1);
+    assert_eq!(result.entries[0].category, BloatCategory::ProjectArtifacts);
+    assert!(result.entries[0].cleanup_hint.as_ref().unwrap().contains("venv"));
+
+    let _ = fs::remove_dir_all(&temp);
+}
+
+#[test]
+fn detects_pytest_cache() {
+    let temp = std::env::temp_dir().join("heft_test_pytest");
+    let _ = fs::remove_dir_all(&temp);
+
+    let project = temp.join("my-test-project");
+    let cache = project.join(".pytest_cache");
+
+    fs::create_dir_all(&cache).unwrap();
+    fs::write(project.join("pyproject.toml"), "[project]\nname = \"test\"").unwrap();
+    fs::write(cache.join("v").join("cache").join("data"), "cached").ok();
+    fs::write(cache.join("README.md"), "pytest cache").unwrap();
+
+    let config = Config {
+        roots: vec![temp.clone()],
+        timeout: Duration::from_secs(30),
+        skip_docker: true,
+        json_output: false,
+        platform: Platform::Linux,
+    };
+
+    let result = scan::run(&config);
+
+    assert_eq!(result.entries.len(), 1);
+    assert_eq!(result.entries[0].category, BloatCategory::ProjectArtifacts);
+
+    let _ = fs::remove_dir_all(&temp);
+}
+
+#[test]
+fn falls_back_to_directory_name_when_manifest_has_no_name() {
+    let temp = std::env::temp_dir().join("heft_test_fallback");
+    let _ = fs::remove_dir_all(&temp);
+
+    let project = temp.join("unnamed-project");
+    let node_modules = project.join("node_modules");
+
+    fs::create_dir_all(&node_modules).unwrap();
+    // package.json exists but has no name field
+    fs::write(project.join("package.json"), r#"{"version": "1.0.0"}"#).unwrap();
+    fs::write(node_modules.join("dep.js"), "x").unwrap();
+
+    let config = Config {
+        roots: vec![temp.clone()],
+        timeout: Duration::from_secs(30),
+        skip_docker: true,
+        json_output: false,
+        platform: Platform::Linux,
+    };
+
+    let result = scan::run(&config);
+
+    assert_eq!(result.entries.len(), 1);
+    // should fall back to directory name
+    assert_eq!(result.entries[0].name, "unnamed-project");
+
+    let _ = fs::remove_dir_all(&temp);
+}
+
+#[test]
+fn does_not_detect_target_without_cargo_toml() {
+    let temp = std::env::temp_dir().join("heft_test_no_cargo");
+    let _ = fs::remove_dir_all(&temp);
+
+    let project = temp.join("not-rust");
+    let target = project.join("target");
+
+    fs::create_dir_all(&target).unwrap();
+    // no Cargo.toml - target could be a different kind of directory
+    fs::write(target.join("output.txt"), "build output").unwrap();
+
+    let config = Config {
+        roots: vec![temp.clone()],
+        timeout: Duration::from_secs(30),
+        skip_docker: true,
+        json_output: false,
+        platform: Platform::Linux,
+    };
+
+    let result = scan::run(&config);
+
+    // should NOT detect as artifact since there's no Cargo.toml
     assert!(result.entries.is_empty());
+
+    let _ = fs::remove_dir_all(&temp);
 }


### PR DESCRIPTION
walks configured root directories looking for known build artifact patterns: node_modules, cargo target/, python venvs and caches, go vendor, gradle build dirs, and xcode deriveddata.

for each detected artifact:
- extracts project name from manifest (package.json, Cargo.toml, go.mod)
- calculates total directory size
- records last modified time of source files
- includes cleanup hint for safe deletion

handles monorepos by aggregating nested artifacts under root project. skips artifacts inside installed packages to avoid noise.

closes #1