### PR TITLE
feat: scan duration and verbose output

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -42,6 +42,10 @@ pub struct ScanArgs {
     /// Per-detector timeout in seconds
     #[arg(long, default_value_t = 30)]
     pub timeout: u64,
+
+    /// Show detailed output including diagnostics
+    #[arg(long, short = 'v', default_value_t = false)]
+    pub verbose: bool,
 }
 
 #[derive(Parser)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,6 +9,7 @@ pub struct Config {
     pub timeout: Duration,
     pub skip_docker: bool,
     pub json_output: bool,
+    pub verbose: bool,
     pub platform: Platform,
 }
 
@@ -27,6 +28,7 @@ impl Config {
             timeout: Duration::from_secs(args.timeout),
             skip_docker: args.no_docker,
             json_output: args.json,
+            verbose: args.verbose,
             platform,
         }
     }
@@ -42,6 +44,7 @@ impl Config {
             timeout: Duration::from_secs(30),
             skip_docker: false,
             json_output: false,
+            verbose: false,
             platform,
         }
     }

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -9,15 +9,33 @@ pub fn print(result: &ScanResult, config: &Config) {
         println!("{}", json::render(result));
     } else {
         print!("{}", table::render(result));
-        print_diagnostics(result);
+        print_scan_info(result);
+        print_diagnostics(result, config.verbose);
     }
 }
 
-fn print_diagnostics(result: &ScanResult) {
-    if !result.diagnostics.is_empty() {
-        println!();
+fn print_scan_info(result: &ScanResult) {
+    if let Some(duration_ms) = result.duration_ms {
+        let duration_sec = duration_ms as f64 / 1000.0;
+        println!("\nscan completed in {:.2}s", duration_sec);
+    }
+}
+
+fn print_diagnostics(result: &ScanResult, verbose: bool) {
+    if result.diagnostics.is_empty() {
+        return;
+    }
+
+    println!();
+    if verbose {
+        println!("Diagnostics:");
+        println!("{}", "-".repeat(40));
         for diagnostic in &result.diagnostics {
-            println!("[diagnostic] {diagnostic}");
+            println!("  {}", diagnostic);
+        }
+    } else {
+        for diagnostic in &result.diagnostics {
+            println!("[diagnostic] {}", diagnostic);
         }
     }
 }

--- a/src/scan/mod.rs
+++ b/src/scan/mod.rs
@@ -12,6 +12,8 @@ use detector::{Detector, DetectorResult, BloatEntry};
 pub struct ScanResult {
     pub entries: Vec<BloatEntry>,
     pub diagnostics: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub duration_ms: Option<u64>,
 }
 
 impl ScanResult {
@@ -19,6 +21,7 @@ impl ScanResult {
         ScanResult {
             entries: Vec::new(),
             diagnostics: Vec::new(),
+            duration_ms: None,
         }
     }
 
@@ -29,6 +32,7 @@ impl ScanResult {
 }
 
 pub fn run(config: &Config) -> ScanResult {
+    let start = std::time::Instant::now();
     let mut scan_result = ScanResult::empty();
 
     let detectors: Vec<Box<dyn Detector>> = vec![
@@ -50,5 +54,6 @@ pub fn run(config: &Config) -> ScanResult {
         scan_result.merge(result);
     }
 
+    scan_result.duration_ms = Some(start.elapsed().as_millis() as u64);
     scan_result
 }


### PR DESCRIPTION
adds two quality of life improvements for scan output

## features added

**scan duration tracking (#26)**
- measures scan time from start to completion
- shows "scan completed in X.XXs" after results
- includes duration_ms in json output
- helps users understand scan performance

**verbose flag (#27)**
- added -v/--verbose flag to scan command
- normal mode: inline `[diagnostic]` messages
- verbose mode: formatted diagnostics section with header
- makes debugging easier and output more readable when needed

## testing

tested with various scans:
- normal table output shows duration
- json output includes duration_ms field
- verbose flag changes diagnostic formatting
- help text shows new flag

both features work correctly in table and json modes

closes #26 #27