### PR TITLE
Phase 1: Detection Accuracy Improvements

### DIFF
--- a/src/scan/caches.rs
+++ b/src/scan/caches.rs
@@ -269,24 +269,39 @@ fn calculate_dir_size(path: &Path) -> Result<(u64, Vec<String>), std::io::Error>
         match entry {
             Ok(entry) => {
                 if entry.file_type().is_file() {
-                    if let Ok(metadata) = entry.metadata() {
-                        let file_size = metadata.len();
-                        match total.checked_add(file_size) {
-                            Some(new_total) => total = new_total,
-                            None => {
-                                if !overflowed {
-                                    warnings.push("directory size exceeds u64::MAX, size capped at maximum value".to_string());
-                                    overflowed = true;
+                    match entry.metadata() {
+                        Ok(metadata) => {
+                            let file_size = metadata.len();
+                            match total.checked_add(file_size) {
+                                Some(new_total) => total = new_total,
+                                None => {
+                                    if !overflowed {
+                                        warnings.push("directory size exceeds u64::MAX, size capped at maximum value".to_string());
+                                        overflowed = true;
+                                    }
+                                    total = u64::MAX;
                                 }
-                                total = u64::MAX;
                             }
+                        }
+                        Err(e) => {
+                            warnings.push(format!("failed to read metadata for {}: {}",
+                                entry.path().display(), e));
                         }
                     }
                 }
             }
             Err(e) => {
+                let path_str = e.path()
+                    .map(|p| p.display().to_string())
+                    .unwrap_or_else(|| "unknown path".to_string());
+
                 if e.io_error().map(|io_err| io_err.kind() == std::io::ErrorKind::PermissionDenied).unwrap_or(false) {
-                    warnings.push(format!("permission denied: {}", e.path().map(|p| p.display().to_string()).unwrap_or_else(|| "unknown path".to_string())));
+                    warnings.push(format!("permission denied: {}", path_str));
+                } else if e.loop_ancestor().is_some() {
+                    warnings.push(format!("symlink loop detected: {}", path_str));
+                } else {
+                    // other errors: I/O errors, invalid UTF-8, filesystem issues
+                    warnings.push(format!("failed to traverse {}: {}", path_str, e));
                 }
             }
         }


### PR DESCRIPTION
phase 1 of the fix roadmap - improving detection accuracy to prevent false positives and make sure we're flagging the right stuff for cleanup.

## what's fixed so far

**#49 - build directory false positives**
any directory named "build" was getting flagged as gradle output if build.gradle existed anywhere up the tree. now we verify the build dir actually contains gradle artifacts (classes/, libs/, tmp/, generated/, intermediates/) before flagging it.

added is_gradle_build_dir() helper that checks for gradle-specific subdirectories. prevents false positives on legitimate build folders used for docs, artifacts, or other purposes.

**#50 - DerivedData false positives** 
any folder named "DerivedData" was flagged as xcode artifacts without checking if xcode was ever used. now we verify with three checks:
1. is it in ~/Library/Developer/Xcode/DerivedData?
2. are there .xcodeproj or .xcworkspace files in parent directories?
3. does it contain xcode subdirectories like Build/, Logs/, ModuleCache/?

also fixed a logic bug where operator precedence was wrong in the location check.

## what's coming next

**#51 - metadata errors silently ignored**
need to handle metadata read errors during size calculation instead of silently dropping them.

**#52 - walkdir errors ignored** 
walkdir errors (permission denied, symlink loops, etc) are silently discarded. should log them as diagnostics so users know why some paths weren't scanned.

## testing

all 11 integration tests passing. the fixes add proper validation before flagging directories, which reduces false positives without missing legitimate build artifacts.

once #51 and #52 are done, phase 1 is complete and ready to merge.